### PR TITLE
fix: reset the existing local branch to the latest state of the pull request

### DIFF
--- a/gh.go
+++ b/gh.go
@@ -15,7 +15,7 @@ func checkoutPR(pr PullRequest) error {
 	extensionLogger.Debugf("Checking out #%d\n", pr.Number)
 
 	if !dryRunFlag {
-		_, err := ghExec("pr", "checkout", fmt.Sprintf("%d", pr.Number))
+		_, err := ghExec("pr", "checkout", fmt.Sprintf("%d", pr.Number), "--force")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## What does this PR do?
It adds the `--foce` flag to the `gh pr checkout` call.

## Why is it important?
Because it could be the case that dependabot refreshed a branch that already existed locally, causing a panic
